### PR TITLE
Review code and add RDF parsing

### DIFF
--- a/examples/rdf_cli_commands.bat
+++ b/examples/rdf_cli_commands.bat
@@ -1,0 +1,80 @@
+@echo off
+rem Sample commands demonstrating the parasolpy RDF CLI against the bundled RDF file.
+rem Run from anywhere (parasolpy must be installed, e.g. `pip install -e .`):
+rem     examples\rdf_cli_commands.bat
+rem
+rem Reads the bundled sample at parasolpy\data\sample_traces.rdf and writes CSV
+rem output into examples\_output\.
+
+setlocal enabledelayedexpansion
+
+set REPO=%~dp0..
+set CLI=python -m parasolpy.rdf
+
+set TRACES=%REPO%\parasolpy\data\sample_traces.rdf
+set OUTDIR=%~dp0_output
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+
+echo ============================================================
+echo 1. Info: inspect sample_traces.rdf
+echo ============================================================
+%CLI% info "%TRACES%"
+
+echo.
+echo ============================================================
+echo 2. Convert all slots in sample_traces.rdf (wide format)
+echo    Scalar slots auto-generate a _labels.csv sidecar per output file.
+echo ============================================================
+for /f "usebackq delims=" %%S in (`%CLI% slots "%TRACES%" --series-only`) do (
+    set "SLOT=%%S"
+
+    rem Build a safe filename: replace spaces and dots with underscores
+    set "SAFE=%%S"
+    set "SAFE=!SAFE: =_!"
+    set "SAFE=!SAFE:.=_!"
+
+    set "OUT=%OUTDIR%\output_!SAFE!_wide.csv"
+    echo   slot : !SLOT!
+    echo   out  : !OUT!
+    %CLI% convert "%TRACES%" --slot "!SLOT!" --output "!OUT!" --format wide
+    echo.
+)
+
+echo ============================================================
+echo 3. Convert all slots in sample_traces.rdf (stacked-header wide format)
+echo    Output includes scalar label rows above wide data columns.
+echo ============================================================
+for /f "usebackq delims=" %%S in (`%CLI% slots "%TRACES%" --series-only`) do (
+    set "SLOT=%%S"
+
+    set "SAFE=%%S"
+    set "SAFE=!SAFE: =_!"
+    set "SAFE=!SAFE:.=_!"
+
+    set "OUT=%OUTDIR%\output_!SAFE!_stacked.csv"
+    echo   slot : !SLOT!
+    echo   out  : !OUT!
+    %CLI% convert "%TRACES%" --slot "!SLOT!" --output "!OUT!" --format stacked
+    echo.
+)
+
+echo ============================================================
+echo 4. Convert all slots in sample_traces.rdf (long format)
+echo ============================================================
+for /f "usebackq delims=" %%S in (`%CLI% slots "%TRACES%" --series-only`) do (
+    set "SLOT=%%S"
+
+    set "SAFE=%%S"
+    set "SAFE=!SAFE: =_!"
+    set "SAFE=!SAFE:.=_!"
+
+    set "OUT=%OUTDIR%\output_!SAFE!_long.csv"
+    echo   slot : !SLOT!
+    echo   out  : !OUT!
+    %CLI% convert "%TRACES%" --slot "!SLOT!" --output "!OUT!" --format long
+    echo.
+)
+
+echo Done.
+
+endlocal

--- a/parasolpy/__init__.py
+++ b/parasolpy/__init__.py
@@ -41,6 +41,7 @@ plotting    : plot_trace_heatmap, plot_trace_spaghetti, plot_trace_fan_chart,
 dash_tools  : build_tradeoff_dash_app, load_dash_inputs
 interactive : prompt_experiment_name, prompt_epsilons,
               load_experiment_epsilons, prompt_starting_epsilons
+rdf         : parse_rdf, list_slots
 
 Quick start
 -----------
@@ -92,6 +93,7 @@ from parasolpy.plotting import (
 	plot_trace_monthly_seasonality,
 	plot_trace_spaghetti,
 )
+from parasolpy.rdf import list_slots, parse_rdf
 from parasolpy.reservoir import sequent_peak
 from parasolpy.tradeoff import (
 	append_Kmeans,
@@ -152,6 +154,9 @@ __all__ = [
 	"plot_trace_heatmap",
 	"plot_trace_monthly_seasonality",
 	"plot_trace_spaghetti",
+	# rdf
+	"parse_rdf",
+	"list_slots",
 	# reservoir
 	"sequent_peak",
 	# tradeoff

--- a/parasolpy/dash_tools.py
+++ b/parasolpy/dash_tools.py
@@ -1,6 +1,7 @@
 """Dash-based interactive tradeoff explorer for multi-objective optimization results."""
 
 import argparse
+import warnings
 
 import pandas as pd
 import plotly.express as px
@@ -68,6 +69,11 @@ def build_tradeoff_dash_app(solutions,
 
     colorscales = px.colors.named_colorscales()
     if default_colorscale not in colorscales:
+        warnings.warn(
+            f"Colorscale {default_colorscale!r} not recognized; falling back to 'viridis'.",
+            UserWarning,
+            stacklevel=2,
+        )
         default_colorscale = "viridis"
 
     app = Dash()

--- a/parasolpy/data/sample_traces.rdf
+++ b/parasolpy/data/sample_traces.rdf
@@ -1,0 +1,240 @@
+name:Example Ensemble Runs
+owner:example_user
+description:Synthetic sample for testing
+create_date:2024-1-1 0:00
+number_of_runs:3
+END_PACKAGE_PREAMBLE
+trace:1
+start:2024-1-1 24:00
+end:2024-1-5 24:00
+time_step_unit:day
+unit_quantity:1
+time_steps:5
+consecutive:0
+rule_set:(Example Rules)
+idx_sequential:0
+END_RUN_PREAMBLE
+2024-1-1 24:00
+2024-1-2 24:00
+2024-1-3 24:00
+2024-1-4 24:00
+2024-1-5 24:00
+object_type: LevelPowerReservoir
+object_name: Example Reservoir
+slot_type: SeriesSlot
+slot_name: Pool Elevation
+END_SLOT_PREAMBLE
+units: feet
+scale: 1
+1100.0
+1099.5
+1099.0
+1098.5
+1098.0
+END_COLUMN
+END_SLOT
+object_type: LevelPowerReservoir
+object_name: Example Reservoir
+slot_type: SeriesSlot
+slot_name: Outflow
+END_SLOT_PREAMBLE
+units: cfs
+scale: 1
+500.0
+510.0
+520.0
+530.0
+540.0
+END_COLUMN
+END_SLOT
+object_type: LevelPowerReservoir
+object_name: Example Reservoir
+slot_type: SeriesSlot
+slot_name: Turbine Release
+END_SLOT_PREAMBLE
+units: cfs
+scale: 1
+480.0
+490.0
+500.0
+510.0
+520.0
+END_COLUMN
+END_SLOT
+object_type: DataObj
+object_name: Run Management
+slot_type: ScalarSlot
+slot_name: Trace Historical Year
+END_SLOT_PREAMBLE
+units: NONE
+scale: 1
+1988
+END_COLUMN
+END_SLOT
+object_type: DataObj
+object_name: Run Management
+slot_type: ScalarSlot
+slot_name: Historical Year Percent of Average
+END_SLOT_PREAMBLE
+units: percent
+scale: 1
+95.0
+END_COLUMN
+END_SLOT
+END_RUN
+trace:2
+start:2024-1-1 24:00
+end:2024-1-5 24:00
+time_step_unit:day
+unit_quantity:1
+time_steps:5
+consecutive:0
+rule_set:(Example Rules)
+idx_sequential:0
+END_RUN_PREAMBLE
+2024-1-1 24:00
+2024-1-2 24:00
+2024-1-3 24:00
+2024-1-4 24:00
+2024-1-5 24:00
+object_type: LevelPowerReservoir
+object_name: Example Reservoir
+slot_type: SeriesSlot
+slot_name: Pool Elevation
+END_SLOT_PREAMBLE
+units: feet
+scale: 1
+1101.0
+1100.5
+1100.0
+1099.5
+1099.0
+END_COLUMN
+END_SLOT
+object_type: LevelPowerReservoir
+object_name: Example Reservoir
+slot_type: SeriesSlot
+slot_name: Outflow
+END_SLOT_PREAMBLE
+units: cfs
+scale: 1
+490.0
+500.0
+510.0
+520.0
+530.0
+END_COLUMN
+END_SLOT
+object_type: LevelPowerReservoir
+object_name: Example Reservoir
+slot_type: SeriesSlot
+slot_name: Turbine Release
+END_SLOT_PREAMBLE
+units: cfs
+scale: 1
+470.0
+480.0
+490.0
+500.0
+510.0
+END_COLUMN
+END_SLOT
+object_type: DataObj
+object_name: Run Management
+slot_type: ScalarSlot
+slot_name: Trace Historical Year
+END_SLOT_PREAMBLE
+units: NONE
+scale: 1
+1995
+END_COLUMN
+END_SLOT
+object_type: DataObj
+object_name: Run Management
+slot_type: ScalarSlot
+slot_name: Historical Year Percent of Average
+END_SLOT_PREAMBLE
+units: percent
+scale: 1
+102.0
+END_COLUMN
+END_SLOT
+END_RUN
+trace:3
+start:2024-1-1 24:00
+end:2024-1-5 24:00
+time_step_unit:day
+unit_quantity:1
+time_steps:5
+consecutive:0
+rule_set:(Example Rules)
+idx_sequential:0
+END_RUN_PREAMBLE
+2024-1-1 24:00
+2024-1-2 24:00
+2024-1-3 24:00
+2024-1-4 24:00
+2024-1-5 24:00
+object_type: LevelPowerReservoir
+object_name: Example Reservoir
+slot_type: SeriesSlot
+slot_name: Pool Elevation
+END_SLOT_PREAMBLE
+units: feet
+scale: 1
+1098.0
+1097.5
+1097.0
+1096.5
+1096.0
+END_COLUMN
+END_SLOT
+object_type: LevelPowerReservoir
+object_name: Example Reservoir
+slot_type: SeriesSlot
+slot_name: Outflow
+END_SLOT_PREAMBLE
+units: cfs
+scale: 1
+520.0
+530.0
+540.0
+550.0
+560.0
+END_COLUMN
+END_SLOT
+object_type: LevelPowerReservoir
+object_name: Example Reservoir
+slot_type: SeriesSlot
+slot_name: Turbine Release
+END_SLOT_PREAMBLE
+units: cfs
+scale: 1
+500.0
+510.0
+520.0
+530.0
+540.0
+END_COLUMN
+END_SLOT
+object_type: DataObj
+object_name: Run Management
+slot_type: ScalarSlot
+slot_name: Trace Historical Year
+END_SLOT_PREAMBLE
+units: NONE
+scale: 1
+2003
+END_COLUMN
+END_SLOT
+object_type: DataObj
+object_name: Run Management
+slot_type: ScalarSlot
+slot_name: Historical Year Percent of Average
+END_SLOT_PREAMBLE
+units: percent
+scale: 1
+88.5
+END_COLUMN
+END_SLOT
+END_RUN

--- a/parasolpy/interactive.py
+++ b/parasolpy/interactive.py
@@ -88,7 +88,10 @@ def load_experiment_epsilons(output_folder, experiment_name, objective_names):
         raise FileNotFoundError(f"Experiment file not found: {log_path}")
 
     with open(log_path, "r", encoding="utf-8") as f:
-        record = json.load(f)
+        try:
+            record = json.load(f)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Cannot parse experiment file {log_path}: {e}") from e
 
     if not isinstance(record, dict) or "epsilons" not in record:
         raise ValueError(f"Experiment file is missing an 'epsilons' object: {log_path}")

--- a/parasolpy/ism.py
+++ b/parasolpy/ism.py
@@ -20,8 +20,10 @@ def create_ism_traces(inflow, k, trace_length):
         tuple[numpy.ndarray, numpy.ndarray]:
             - traces: 2-D array of shape ``(trace_length, num_traces)`` where
               each column is one synthetic trace.
-            - indices: 2-D array of the same shape with the original record
-              indices used to construct each trace position.
+            - indices: 2-D array of the same shape. Values are indices into
+              the *doubled* record (``range(0, 2 * len(inflow))``), not the
+              original. Use ``indices % len(inflow)`` to map back to original
+              record positions.
     """
     # the number of traces is a known function of
     # the index k and the total length of the inflow record

--- a/parasolpy/nowak.py
+++ b/parasolpy/nowak.py
@@ -43,6 +43,7 @@ def choose_analog_index(rng, Z, sim_Z):
     W = np.zeros(K)
     for i in range(K):
         W[i] = (1. / (i + 1.)) / sum(1. / k for k in range(1, K + 1))
+    W = W / W.sum()
 
     # here, we only keep the K nearest neighbors based on distance
     neighbors = sorted_Z[0:K]

--- a/parasolpy/rdf.py
+++ b/parasolpy/rdf.py
@@ -51,9 +51,9 @@ from pathlib import Path
 def _normalize_ts(raw: str) -> str:
     """Convert 'YYYY-M-D 24:00' → ISO date 'YYYY-MM-DD'."""
     date_part = raw.split()[0]
-    dt = datetime.strptime(date_part, "%Y-%m-%d")
+    y, m, d = (int(x) for x in date_part.split("-"))
     # RiverWare 24:00 = end of that calendar day — keep as-is
-    return dt.strftime("%Y-%m-%d")
+    return datetime(y, m, d).strftime("%Y-%m-%d")
 
 
 def _parse_preamble(lines: list[str], pos: int, end_marker: str) -> tuple[dict, int]:

--- a/parasolpy/rdf.py
+++ b/parasolpy/rdf.py
@@ -1,0 +1,536 @@
+"""RiverWare RDF file parser and CSV converter.
+
+This module provides both a library API and a command-line interface for
+reading RiverWare RDF files and converting slot data to CSV.
+
+Library
+-------
+    from parasolpy.rdf import parse_rdf, list_slots
+    rdf = parse_rdf("model.rdf")
+    for slot in list_slots(rdf):
+        print(slot["key"])
+
+CLI
+---
+    python -m parasolpy.rdf info <file.rdf>
+    python -m parasolpy.rdf slots <file.rdf> [--series-only]
+    python -m parasolpy.rdf convert <file.rdf> --slot "ObjectName.SlotName" --output out.csv
+    python -m parasolpy.rdf convert <file.rdf> --slot "ObjectName.SlotName" --output out.csv --format wide
+    python -m parasolpy.rdf convert <file.rdf> --slot "ObjectName.SlotName" --output out.csv --format stacked
+    python -m parasolpy.rdf convert <file.rdf> --slot "ObjectName.SlotName" --output out.csv --format long
+    python -m parasolpy.rdf convert <file.rdf> --slot "ObjectName.SlotName" --output out.csv --format enriched
+
+RDF format (text, one token per line):
+  Package preamble  key:value ... END_PACKAGE_PREAMBLE
+  Per run:
+    Run preamble    key:value ... END_RUN_PREAMBLE
+    Timestep list   YYYY-M-D 24:00  (time_steps lines)
+    Per slot:
+      Slot preamble key:value ... END_SLOT_PREAMBLE
+      units line
+      scale line
+      values        (time_steps lines for series; 1 line for scalar)
+      END_COLUMN
+      END_SLOT
+    END_RUN
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+import warnings
+from datetime import datetime
+from pathlib import Path
+
+
+# --------------------------------------------------------------------------- #
+# Parser
+# --------------------------------------------------------------------------- #
+def _normalize_ts(raw: str) -> str:
+    """Convert 'YYYY-M-D 24:00' → ISO date 'YYYY-MM-DD'."""
+    date_part = raw.split()[0]
+    dt = datetime.strptime(date_part, "%Y-%m-%d")
+    # RiverWare 24:00 = end of that calendar day — keep as-is
+    return dt.strftime("%Y-%m-%d")
+
+
+def _parse_preamble(lines: list[str], pos: int, end_marker: str) -> tuple[dict, int]:
+    """
+    Read key:value lines from pos until end_marker (exclusive).
+    Returns (dict, new_pos).  end_marker line is consumed.
+    If end_marker == 1 (int), reads exactly one line.
+    """
+    result: dict = {}
+    while pos < len(lines):
+        line = lines[pos]
+        pos += 1
+        if line == end_marker:
+            break
+        parts = line.split(":", 1)
+        key = parts[0].strip()
+        value = parts[1].strip() if len(parts) > 1 else None
+        result[key] = value
+        if end_marker == 1:  # sentinel: read exactly one line
+            break
+    return result, pos
+
+
+def _parse_slot(lines: list[str], pos: int, nts: int) -> tuple[dict, int]:
+    """Parse one slot block starting at pos (first line = object_type or similar)."""
+    slot, pos = _parse_preamble(lines, pos, "END_SLOT_PREAMBLE")
+
+    # units and scale are bare single-value lines (no key prefix)
+    units_line = lines[pos]; pos += 1
+    scale_line = lines[pos]; pos += 1
+
+    # Parse bare "key: value" or just "value"
+    def _bare_value(line: str) -> str:
+        return line.split(":", 1)[-1].strip() if ":" in line else line.strip()
+
+    slot["units"] = _bare_value(units_line)
+    slot["scale"] = _bare_value(scale_line)
+
+    # Find next END_COLUMN to determine scalar vs series
+    ec_idx = next(
+        (i for i in range(pos, len(lines)) if lines[i] == "END_COLUMN"),
+        None,
+    )
+    if ec_idx is None:
+        raise ValueError(f"END_COLUMN not found after position {pos}")
+
+    n_values = ec_idx - pos
+    slot_type = (slot.get("slot_type") or "").strip().lower()
+    is_series_slot = "series" in slot_type
+    is_scalar_slot = "scalar" in slot_type
+
+    if is_series_slot:
+        slot["scalar"] = False
+    elif is_scalar_slot:
+        slot["scalar"] = True
+    elif n_values == nts:
+        slot["scalar"] = False
+    elif n_values == 1:
+        slot["scalar"] = True
+    else:
+        warnings.warn(
+            f"Slot '{slot.get('object_name')}.{slot.get('slot_name')}': "
+            f"expected {nts} or 1 values, found {n_values}. Skipping."
+        )
+        slot["values"] = []
+        slot["scalar"] = None
+        pos = ec_idx + 1  # skip to after END_COLUMN
+        if pos < len(lines) and lines[pos] == "END_SLOT":
+            pos += 1
+        return slot, pos
+
+    raw_values = lines[pos : pos + n_values]
+    try:
+        slot["values"] = [float(v) for v in raw_values]
+    except ValueError:
+        slot["values"] = raw_values  # keep as strings if not numeric
+
+    pos = ec_idx + 1  # advance past END_COLUMN
+    if pos < len(lines) and lines[pos] == "END_SLOT":
+        pos += 1
+
+    return slot, pos
+
+
+def _parse_run(lines: list[str], pos: int) -> tuple[dict, int]:
+    """Parse one run block.  pos points to first line after END_PACKAGE_PREAMBLE
+    (or after previous END_RUN)."""
+    run: dict = {}
+
+    preamble, pos = _parse_preamble(lines, pos, "END_RUN_PREAMBLE")
+    run["preamble"] = preamble
+
+    nts = int(preamble.get("time_steps") or preamble.get("timesteps") or 0)
+
+    # Read timestep list
+    raw_times = lines[pos : pos + nts]
+    run["times"] = [_normalize_ts(t) for t in raw_times]
+    pos += nts
+
+    # Read slots until END_RUN
+    run["slots"] = {}
+    while pos < len(lines):
+        if lines[pos] == "END_RUN":
+            pos += 1
+            break
+
+        slot, pos = _parse_slot(lines, pos, nts)
+        key = f"{slot.get('object_name', '')}.{slot.get('slot_name', '')}"
+        run["slots"][key] = slot
+
+    return run, pos
+
+
+def parse_rdf(path: str | Path) -> dict:
+    """
+    Parse a RiverWare RDF file.
+
+    Returns:
+        {
+            "meta": {key: value, ...},
+            "runs": [
+                {
+                    "preamble": {key: value, ...},
+                    "times": ["YYYY-MM-DD", ...],
+                    "slots": {
+                        "ObjectName.SlotName": {
+                            "object_type": ..., "object_name": ...,
+                            "slot_type": ..., "slot_name": ...,
+                            "units": ..., "scale": ...,
+                            "scalar": bool,
+                            "values": [float, ...]
+                        },
+                        ...
+                    }
+                },
+                ...
+            ]
+        }
+    """
+    path = Path(path)
+    if path.suffix.lower() != ".rdf":
+        raise ValueError(f"{path} does not appear to be an rdf file.")
+    if not path.exists():
+        raise FileNotFoundError(f"{path} does not exist.")
+
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    # Strip carriage returns from Windows line endings
+    lines = [ln.rstrip("\r") for ln in lines]
+
+    pos = 0
+    meta, pos = _parse_preamble(lines, pos, "END_PACKAGE_PREAMBLE")
+
+    expected_runs = int(meta.get("number_of_runs") or 0)
+    runs: list[dict] = []
+
+    while len(runs) < expected_runs and pos < len(lines):
+        run, pos = _parse_run(lines, pos)
+        runs.append(run)
+
+    return {"meta": meta, "runs": runs}
+
+
+def list_slots(rdf: dict) -> list[dict]:
+    """Return slot metadata list from first run (all runs share the same slots)."""
+    if not rdf["runs"]:
+        return []
+    return [
+        {
+            "key": key,
+            "object_name": s.get("object_name", ""),
+            "slot_name": s.get("slot_name", ""),
+            "object_type": s.get("object_type", ""),
+            "slot_type": s.get("slot_type", ""),
+            "units": s.get("units", ""),
+            "scale": s.get("scale", ""),
+            "scalar": s.get("scalar"),
+        }
+        for key, s in rdf["runs"][0]["slots"].items()
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# CSV writers
+# --------------------------------------------------------------------------- #
+def _scalar_keys(runs: list[dict]) -> list[str]:
+    first_slots = runs[0]["slots"]
+    return [k for k, v in first_slots.items() if v.get("scalar")]
+
+
+def _stacked_date_col_name(ref_times: list[str]) -> str:
+    # Annual data in sample files is represented by Jan 1 timestamps.
+    if ref_times and all(t.endswith("-01-01") for t in ref_times):
+        return "year"
+    return "date"
+
+
+def _trace_id(run: dict) -> str:
+    return f"trace_{run['preamble'].get('trace', '?')}"
+
+
+def _write_wide(
+    runs: list[dict], slot_key: str, ref_times: list[str], out_path: Path
+) -> None:
+    headers = ["date"] + [_trace_id(r) for r in runs]
+
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(headers)
+
+        # Determine row count from first run's slot
+        first_values = runs[0]["slots"][slot_key]["values"]
+        n_rows = len(first_values)
+
+        for row_i in range(n_rows):
+            date = ref_times[row_i] if row_i < len(ref_times) else ""
+            row = [date]
+            for run in runs:
+                vals = run["slots"][slot_key]["values"]
+                row.append(vals[row_i] if row_i < len(vals) else "")
+            writer.writerow(row)
+
+
+def _write_long(
+    runs: list[dict], slot_key: str, ref_times: list[str], out_path: Path
+) -> None:
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["date", "trace", "value"])
+        for run in runs:
+            trace = _trace_id(run)
+            vals = run["slots"][slot_key]["values"]
+            for i, val in enumerate(vals):
+                date = ref_times[i] if i < len(ref_times) else ""
+                writer.writerow([date, trace, val])
+
+
+def _write_stacked_header(
+    runs: list[dict],
+    slot_key: str,
+    ref_times: list[str],
+    out_path: Path,
+    scalar_keys: list[str],
+) -> None:
+    trace_ids = [_trace_id(r) for r in runs]
+    date_col = _stacked_date_col_name(ref_times)
+
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+
+        for sk in scalar_keys:
+            label_name = sk.split(".", 1)[1] if "." in sk else sk
+            label_vals = []
+            for run in runs:
+                vals = run["slots"][sk]["values"]
+                label_vals.append(vals[0] if vals else "")
+            writer.writerow([label_name] + label_vals)
+
+        writer.writerow([date_col] + trace_ids)
+
+        first_values = runs[0]["slots"][slot_key]["values"]
+        n_rows = len(first_values)
+        for row_i in range(n_rows):
+            date = ref_times[row_i] if row_i < len(ref_times) else ""
+            row = [date]
+            for run in runs:
+                vals = run["slots"][slot_key]["values"]
+                row.append(vals[row_i] if row_i < len(vals) else "")
+            writer.writerow(row)
+
+
+def _write_enriched(
+    runs: list[dict], slot_key: str, ref_times: list[str], out_path: Path
+) -> None:
+    """Stacked format with scalar slot values appended as label columns."""
+    scalar_keys = _scalar_keys(runs)
+    category_names = [k.split(".", 1)[1] if "." in k else k for k in scalar_keys]
+
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["date", "trace", "value"] + category_names)
+        for run in runs:
+            trace = _trace_id(run)
+            vals = run["slots"][slot_key]["values"]
+            scalar_vals = [run["slots"][sk]["values"][0] if run["slots"][sk]["values"] else ""
+                           for sk in scalar_keys]
+            for i, val in enumerate(vals):
+                date = ref_times[i] if i < len(ref_times) else ""
+                writer.writerow([date, trace, val] + scalar_vals)
+
+
+def _write_sidecar(runs: list[dict], out_path: Path) -> Path | None:
+    """Write <stem>_labels.csv with one row per trace and one column per scalar slot.
+
+    Returns the sidecar path, or None if no scalar slots exist.
+    """
+    scalar_keys = _scalar_keys(runs)
+    if not scalar_keys:
+        return None
+
+    sidecar_path = out_path.with_name(out_path.stem + "_labels.csv")
+    # Use just the slot_name portion (after the dot) as the category header.
+    category_names = [k.split(".", 1)[1] if "." in k else k for k in scalar_keys]
+
+    with sidecar_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["column"] + category_names)
+        for run in runs:
+            row = [_trace_id(run)]
+            for sk in scalar_keys:
+                vals = run["slots"][sk]["values"]
+                row.append(vals[0] if vals else "")
+            writer.writerow(row)
+
+    return sidecar_path
+
+
+# --------------------------------------------------------------------------- #
+# CLI commands
+# --------------------------------------------------------------------------- #
+def cmd_info(args: argparse.Namespace) -> None:
+    rdf = parse_rdf(args.file)
+    meta = rdf["meta"]
+    runs = rdf["runs"]
+
+    print("=== Package metadata ===")
+    for k, v in meta.items():
+        print(f"  {k}: {v}")
+
+    if runs:
+        first = runs[0]["preamble"]
+        last = runs[-1]["preamble"]
+        print(f"\n=== Runs ===")
+        print(f"  count         : {len(runs)}")
+        print(f"  time_step_unit: {first.get('time_step_unit', 'unknown')}")
+        print(f"  first run     : trace={first.get('trace')}  "
+              f"start={first.get('start')}  end={first.get('end')}  "
+              f"time_steps={first.get('time_steps')}")
+        print(f"  last run      : trace={last.get('trace')}  "
+              f"start={last.get('start')}  end={last.get('end')}")
+
+    slots = list_slots(rdf)
+    if slots:
+        print(f"\n=== Slots ({len(slots)}) ===")
+        col_w = max(len(s["key"]) for s in slots) + 2
+        header = f"  {'slot':<{col_w}}  {'type':<18}  {'units':<12}  scalar"
+        print(header)
+        print("  " + "-" * (len(header) - 2))
+        for s in slots:
+            print(
+                f"  {s['key']:<{col_w}}  {s['slot_type']:<18}  "
+                f"{s['units']:<12}  {s['scalar']}"
+            )
+    else:
+        print("No slots found.")
+
+
+def cmd_convert(args: argparse.Namespace) -> None:
+    rdf = parse_rdf(args.file)
+    runs = rdf["runs"]
+
+    if not runs:
+        print("No runs found in file.", file=sys.stderr)
+        sys.exit(1)
+
+    slot_key = args.slot
+
+    # Validate slot exists
+    available = list(runs[0]["slots"].keys())
+    if slot_key not in available:
+        print(f"Slot '{slot_key}' not found.", file=sys.stderr)
+        print("Available slots:", file=sys.stderr)
+        for k in available:
+            print(f"  {k}", file=sys.stderr)
+        sys.exit(1)
+
+    # Warn if timesteps differ across runs
+    ref_times = runs[0]["times"]
+    for i, run in enumerate(runs[1:], start=2):
+        if run["times"] != ref_times:
+            warnings.warn(
+                f"Run {i} (trace={run['preamble'].get('trace')}) has different "
+                f"timesteps from run 1. Using run 1 timesteps for date column."
+            )
+
+    slot_info = runs[0]["slots"][slot_key]
+    if slot_info.get("scalar"):
+        print(
+            f"Warning: '{slot_key}' is a scalar slot (1 value per run, not per timestep). "
+            "Output will have 1 data row.",
+            file=sys.stderr,
+        )
+
+    out_path = Path(args.output)
+
+    fmt = args.format if args.format is not None else "wide"
+    scalar_keys = _scalar_keys(runs)
+
+    if fmt == "wide":
+        _write_wide(runs, slot_key, ref_times, out_path)
+        sidecar_path = _write_sidecar(runs, out_path)
+        print(f"Wrote {out_path}")
+        if sidecar_path:
+            print(f"Wrote {sidecar_path}")
+    elif fmt == "stacked":
+        if not scalar_keys:
+            print(
+                "Format 'stacked' requires scalar slots for label header rows. "
+                "No scalar slots were found.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        _write_stacked_header(runs, slot_key, ref_times, out_path, scalar_keys)
+        print(f"Wrote {out_path}")
+    elif fmt == "long":
+        _write_long(runs, slot_key, ref_times, out_path)
+        print(f"Wrote {out_path}")
+    else:  # enriched
+        _write_enriched(runs, slot_key, ref_times, out_path)
+        print(f"Wrote {out_path}")
+
+
+def cmd_slots(args: argparse.Namespace) -> None:
+    """Print one slot key per line — useful for scripting."""
+    rdf = parse_rdf(args.file)
+    for s in list_slots(rdf):
+        if args.series_only and s["scalar"]:
+            continue
+        print(s["key"])
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="parasolpy-rdf",
+        description="Read and convert RiverWare RDF files.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # info
+    p_info = sub.add_parser("info", help="Print metadata and slot list.")
+    p_info.add_argument("file", help="Path to .rdf file.")
+
+    # slots
+    p_slots = sub.add_parser("slots", help="Print slot names one per line (for scripting).")
+    p_slots.add_argument("file", help="Path to .rdf file.")
+    p_slots.add_argument("--series-only", action="store_true",
+                         help="Exclude scalar slots; print series slots only.")
+
+    # convert
+    p_conv = sub.add_parser("convert", help="Export a slot to CSV.")
+    p_conv.add_argument("file", help="Path to .rdf file.")
+    p_conv.add_argument(
+        "--slot",
+        required=True,
+        metavar="OBJECT.SLOT",
+        help='Slot to export, e.g. "Example Reservoir.Pool Elevation".',
+    )
+    p_conv.add_argument("--output", required=True, metavar="PATH", help="Output CSV path.")
+    p_conv.add_argument(
+        "--format",
+        choices=["wide", "stacked", "long", "enriched"],
+        default=None,
+        help=(
+            "Output format. Default: wide. "
+            "Options: wide (wide + optional sidecar), stacked (wide with scalar "
+            "label header rows), long (date/trace/value), enriched (long + labels)."
+        ),
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "info":
+        cmd_info(args)
+    elif args.command == "slots":
+        cmd_slots(args)
+    elif args.command == "convert":
+        cmd_convert(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/parasolpy/tradeoff.py
+++ b/parasolpy/tradeoff.py
@@ -384,8 +384,8 @@ def label_eps_nd(
     eps_ids = [sol.id for sol in eps_pt]
 
     # add labels to the epsilon non-dominated solutions
-    for id in eps_ids:
-        df.at[id, label_col] = True
+    for sol_id in eps_ids:
+        df.at[sol_id, label_col] = True
 
     return df
 

--- a/parasolpy/tradeoff.py
+++ b/parasolpy/tradeoff.py
@@ -13,94 +13,99 @@ from parasolpy.util import process_xml
 
 
 def df_to_pt(df, obj_names, obj_directions, num_vars=0, num_constrs=0):
-  """
-  Converts a pandas DataFrame of solutions into a list of Platypus Solution objects.
+    """
+    Converts a pandas DataFrame of solutions into a list of Platypus Solution objects.
 
-  This function takes a DataFrame where each row represents a solution and columns
-  represent objectives (and potentially decision variables or constraints).
-  It creates Platypus Problem and Solution objects, mapping DataFrame rows
-  to solutions and objective columns to Platypus objectives, handling minimization
-  and maximization as specified.
+    This function takes a DataFrame where each row represents a solution and columns
+    represent objectives (and potentially decision variables or constraints).
+    It creates Platypus Problem and Solution objects, mapping DataFrame rows
+    to solutions and objective columns to Platypus objectives, handling minimization
+    and maximization as specified.
 
-  Args:
-    df (pd.DataFrame): The input DataFrame where each row is a solution.
-    obj_names (list of str): A list of column names in `df` that represent
-                                   the objective functions.
-    obj_directions (list of str): A list of strings ('minimize' or 'maximize')
-                                        indicating the optimization direction for
-                                        each objective. Must match the order of
-                                        `obj_names_param`.
-    num_vars (int, optional): The number of decision variables in the problem.
-                           Defaults to 0.
-    num_constrs (int, optional): The number of constraints in the problem.
-                              Defaults to 0.
+    Args:
+      df (pd.DataFrame): The input DataFrame where each row is a solution.
+      obj_names (list of str): A list of column names in `df` that represent
+                                     the objective functions.
+      obj_directions (list of str): A list of strings ('minimize' or 'maximize')
+                                          indicating the optimization direction for
+                                          each objective. Must match the order of
+                                          `obj_names_param`.
+      num_vars (int, optional): The number of decision variables in the problem.
+                             Defaults to 0.
+      num_constrs (int, optional): The number of constraints in the problem.
+                                Defaults to 0.
 
-  Returns:
-    list: A list of Platypus Solution objects, each representing a row from
-          the input DataFrame.
+    Returns:
+      list: A list of Platypus Solution objects, each representing a row from
+            the input DataFrame.
 
-  Raises:
-    TypeError: If `df` is not a pandas DataFrame, or if `obj_names`,
-               `obj_directions` are not lists of strings.
-    ValueError: If `obj_names` is empty, objective directions are invalid,
-                lengths of `obj_names` and `obj_directions` do not match,
-                or `num_vars`/`num_constrs` are not non-negative integers.
-  """
-  # Validate input parameters
-  if not isinstance(df, pd.DataFrame):
-    raise TypeError("Input 'df' must be a pandas DataFrame.")
-  if not isinstance(obj_names, list) or not all(isinstance(name, str) for name in obj_names):
-    raise TypeError("Input 'obj_names' must be a list of strings.")
-  if not obj_names:
-    raise ValueError("Input 'obj_names' cannot be empty.")
-  if not isinstance(obj_directions, list) or not all(isinstance(direction, str) for direction in obj_directions):
-    raise TypeError("Input 'obj_directions' must be a list of strings.")
-  if not all(d in ['minimize', 'maximize'] for d in obj_directions):
-    raise ValueError("Objective directions must be 'minimize' or 'maximize'.")
-  if len(obj_names) != len(obj_directions):
-    raise ValueError("Length of 'obj_names' must match 'obj_directions'.")
-  if not isinstance(num_vars, int) or num_vars < 0:
-    raise ValueError("Input 'nvars' must be a non-negative integer.")
-  if not isinstance(num_constrs, int) or num_constrs < 0:
-    raise ValueError("Input 'nconstrs' must be a non-negative integer.")
+    Raises:
+      TypeError: If `df` is not a pandas DataFrame, or if `obj_names`,
+                 `obj_directions` are not lists of strings.
+      ValueError: If `obj_names` is empty, objective directions are invalid,
+                  lengths of `obj_names` and `obj_directions` do not match,
+                  or `num_vars`/`num_constrs` are not non-negative integers.
+    """
+    # Validate input parameters
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("Input 'df' must be a pandas DataFrame.")
+    if not isinstance(obj_names, list) or not all(
+        isinstance(name, str) for name in obj_names
+    ):
+        raise TypeError("Input 'obj_names' must be a list of strings.")
+    if not obj_names:
+        raise ValueError("Input 'obj_names' cannot be empty.")
+    if not isinstance(obj_directions, list) or not all(
+        isinstance(direction, str) for direction in obj_directions
+    ):
+        raise TypeError("Input 'obj_directions' must be a list of strings.")
+    if not all(d in ["minimize", "maximize"] for d in obj_directions):
+        raise ValueError("Objective directions must be 'minimize' or 'maximize'.")
+    if len(obj_names) != len(obj_directions):
+        raise ValueError("Length of 'obj_names' must match 'obj_directions'.")
+    if not isinstance(num_vars, int) or num_vars < 0:
+        raise ValueError("Input 'nvars' must be a non-negative integer.")
+    if not isinstance(num_constrs, int) or num_constrs < 0:
+        raise ValueError("Input 'nconstrs' must be a non-negative integer.")
 
-  num_objs = len(obj_names)
-  problem = pt.Problem(nvars=num_vars, nobjs=num_objs, nconstrs=num_constrs)
-  pt_solutions = []
-  for index, row in df.iterrows():
-    # create solution object
-    solution = pt.Solution(problem)
+    num_objs = len(obj_names)
+    problem = pt.Problem(nvars=num_vars, nobjs=num_objs, nconstrs=num_constrs)
+    pt_solutions = []
+    for index, row in df.iterrows():
+        # create solution object
+        solution = pt.Solution(problem)
 
-    # save an id for which row of the original
-    # dataframe this solution came from. really important
-    # for cross-referencing things later!
-    solution.id = index
+        # save an id for which row of the original
+        # dataframe this solution came from. really important
+        # for cross-referencing things later!
+        solution.id = index
 
-    # populate the objective values into platypus, correcting
-    # the maximized objectives by multiplying by -1
-    for j in range(num_objs):
-      if obj_directions[j] == 'minimize':
-        solution.objectives[j] = row[obj_names[j]]
-      elif obj_directions[j] == 'maximize':
-        solution.objectives[j] = -1.0*row[obj_names[j]]
+        # populate the objective values into platypus, correcting
+        # the maximized objectives by multiplying by -1
+        for j in range(num_objs):
+            if obj_directions[j] == "minimize":
+                solution.objectives[j] = row[obj_names[j]]
+            elif obj_directions[j] == "maximize":
+                solution.objectives[j] = -1.0 * row[obj_names[j]]
 
-    # add the solution to the list
-    pt_solutions.append(solution)
-  return pt_solutions
+        # add the solution to the list
+        pt_solutions.append(solution)
+    return pt_solutions
 
 
-def parallel_plot_hp(df,
-                     obj_names=None,
-                     obj_directions=None,
-                     plot_direction='bottom',
-                     color_column=None,
-                     hide_columns=None,
-                     forced_ranges_columns=None,
-                     force_min=None,
-                     force_max=None,
-                     colormap='interpolateViridis',
-                     invert_columns=None
-                     ):
+def parallel_plot_hp(
+    df,
+    obj_names=None,
+    obj_directions=None,
+    plot_direction="bottom",
+    color_column=None,
+    hide_columns=None,
+    forced_ranges_columns=None,
+    force_min=None,
+    force_max=None,
+    colormap="interpolateViridis",
+    invert_columns=None,
+):
     """
     Generates an interactive parallel plot using HiPlot for visualizing solution tradeoffs.
 
@@ -145,81 +150,110 @@ def parallel_plot_hp(df,
     if not isinstance(df, pd.DataFrame):
         raise TypeError("Input 'df' must be a pandas DataFrame.")
 
-    if not isinstance(plot_direction, str) or plot_direction not in ['bottom', 'top']:
-        raise ValueError(
-            "Input 'plot_direction' must be either 'bottom' or 'top'.")
+    if not isinstance(plot_direction, str) or plot_direction not in ["bottom", "top"]:
+        raise ValueError("Input 'plot_direction' must be either 'bottom' or 'top'.")
 
     if color_column is not None:
         if not isinstance(color_column, str):
             raise TypeError("Input 'color_column' must be a string or None.")
         if color_column not in df.columns:
             raise ValueError(
-                f"'color_column' '{color_column}' not found in DataFrame columns.")
+                f"'color_column' '{color_column}' not found in DataFrame columns."
+            )
 
     if not isinstance(colormap, str) or not colormap:
-      raise TypeError("Input 'colormap' must be a non-empty string.")
+        raise TypeError("Input 'colormap' must be a non-empty string.")
 
     if hide_columns is not None:
-        if not isinstance(hide_columns, list) or not all(isinstance(col, str) for col in hide_columns):
+        if not isinstance(hide_columns, list) or not all(
+            isinstance(col, str) for col in hide_columns
+        ):
             raise TypeError("Input 'hide_columns' must be a list of strings.")
-        invalid_hide_columns = [
-            col for col in hide_columns if col not in df.columns]
+        invalid_hide_columns = [col for col in hide_columns if col not in df.columns]
         if invalid_hide_columns:
             raise ValueError(
-                f"Columns to hide {invalid_hide_columns} not found in DataFrame.")
+                f"Columns to hide {invalid_hide_columns} not found in DataFrame."
+            )
 
     if invert_columns is not None:
-      if not isinstance(invert_columns, list) or not all(isinstance(col, str) for col in invert_columns):
-        raise TypeError("Input 'invert_columns' must be a list of strings.")
-      invalid_invert_columns = [col for col in invert_columns if col not in df.columns]
-      if invalid_invert_columns:
-        raise ValueError(
-          f"Columns to invert {invalid_invert_columns} not found in DataFrame.")
+        if not isinstance(invert_columns, list) or not all(
+            isinstance(col, str) for col in invert_columns
+        ):
+            raise TypeError("Input 'invert_columns' must be a list of strings.")
+        invalid_invert_columns = [
+            col for col in invert_columns if col not in df.columns
+        ]
+        if invalid_invert_columns:
+            raise ValueError(
+                f"Columns to invert {invalid_invert_columns} not found in DataFrame."
+            )
 
     if obj_names is not None:
-      if not isinstance(obj_names, list) or not all(isinstance(col, str) for col in obj_names):
-        raise TypeError("Input 'obj_names' must be a list of strings or None.")
-      invalid_obj_names = [col for col in obj_names if col not in df.columns]
-      if invalid_obj_names:
-        raise ValueError(
-          f"Objective columns {invalid_obj_names} not found in DataFrame.")
+        if not isinstance(obj_names, list) or not all(
+            isinstance(col, str) for col in obj_names
+        ):
+            raise TypeError("Input 'obj_names' must be a list of strings or None.")
+        invalid_obj_names = [col for col in obj_names if col not in df.columns]
+        if invalid_obj_names:
+            raise ValueError(
+                f"Objective columns {invalid_obj_names} not found in DataFrame."
+            )
 
     if obj_directions is not None:
-      if not isinstance(obj_directions, list) or not all(isinstance(direction, str) for direction in obj_directions):
-        raise TypeError("Input 'obj_directions' must be a list of strings or None.")
-      invalid_dirs = [d for d in obj_directions if d not in ['minimize', 'maximize']]
-      if invalid_dirs:
-        raise ValueError("Objective directions must be 'minimize' or 'maximize'.")
+        if not isinstance(obj_directions, list) or not all(
+            isinstance(direction, str) for direction in obj_directions
+        ):
+            raise TypeError("Input 'obj_directions' must be a list of strings or None.")
+        invalid_dirs = [d for d in obj_directions if d not in ["minimize", "maximize"]]
+        if invalid_dirs:
+            raise ValueError("Objective directions must be 'minimize' or 'maximize'.")
 
     if (obj_names is None) != (obj_directions is None):
-      raise ValueError("Inputs 'obj_names' and 'obj_directions' must both be provided or both be None.")
+        raise ValueError(
+            "Inputs 'obj_names' and 'obj_directions' must both be provided or both be None."
+        )
 
     if obj_names is not None and len(obj_names) != len(obj_directions):
-      raise ValueError("Lengths of 'obj_names' and 'obj_directions' must match.")
+        raise ValueError("Lengths of 'obj_names' and 'obj_directions' must match.")
 
     if forced_ranges_columns is not None:
-      if not isinstance(forced_ranges_columns, list) or not all(isinstance(col, str) for col in forced_ranges_columns):
-        raise TypeError("Input 'forced_ranges_columns' must be a list of strings.")
-      invalid_forced_cols = [col for col in forced_ranges_columns if col not in df.columns]
-      if invalid_forced_cols:
-        raise ValueError(
-          f"Forced-range columns {invalid_forced_cols} not found in DataFrame.")
+        if not isinstance(forced_ranges_columns, list) or not all(
+            isinstance(col, str) for col in forced_ranges_columns
+        ):
+            raise TypeError("Input 'forced_ranges_columns' must be a list of strings.")
+        invalid_forced_cols = [
+            col for col in forced_ranges_columns if col not in df.columns
+        ]
+        if invalid_forced_cols:
+            raise ValueError(
+                f"Forced-range columns {invalid_forced_cols} not found in DataFrame."
+            )
 
     if force_min is not None:
-      if not isinstance(force_min, list) or not all(isinstance(v, (int, float)) for v in force_min):
-        raise TypeError("Input 'force_min' must be a list of numbers.")
+        if not isinstance(force_min, list) or not all(
+            isinstance(v, (int, float)) for v in force_min
+        ):
+            raise TypeError("Input 'force_min' must be a list of numbers.")
 
     if force_max is not None:
-      if not isinstance(force_max, list) or not all(isinstance(v, (int, float)) for v in force_max):
-        raise TypeError("Input 'force_max' must be a list of numbers.")
+        if not isinstance(force_max, list) or not all(
+            isinstance(v, (int, float)) for v in force_max
+        ):
+            raise TypeError("Input 'force_max' must be a list of numbers.")
 
-    if forced_ranges_columns is not None or force_min is not None or force_max is not None:
-      if forced_ranges_columns is None or force_min is None or force_max is None:
-        raise ValueError(
-          "Inputs 'forced_ranges_columns', 'force_min', and 'force_max' must all be provided together.")
-      if not (len(forced_ranges_columns) == len(force_min) == len(force_max)):
-        raise ValueError(
-          "Lengths of 'forced_ranges_columns', 'force_min', and 'force_max' must match.")
+    if (
+        forced_ranges_columns is not None
+        or force_min is not None
+        or force_max is not None
+    ):
+        if forced_ranges_columns is None or force_min is None or force_max is None:
+            raise ValueError(
+                "Inputs 'forced_ranges_columns', 'force_min', and 'force_max' must all be provided together."
+            )
+        if not (len(forced_ranges_columns) == len(force_min) == len(force_max)):
+            raise ValueError(
+                "Lengths of 'forced_ranges_columns', 'force_min', and 'force_max' must match."
+            )
 
     # Convert the default 'None' to list types
     if hide_columns is None:
@@ -231,18 +265,18 @@ def parallel_plot_hp(df,
     if invert_columns is not None:
         pp_invert = invert_columns
     elif obj_names is not None and obj_directions is not None:
-        if plot_direction == 'bottom':
+        if plot_direction == "bottom":
             for j in range(len(obj_names)):
-                if obj_directions[j] == 'maximize':
+                if obj_directions[j] == "maximize":
                     pp_invert.append(obj_names[j])
-        elif plot_direction == 'top':
+        elif plot_direction == "top":
             for j in range(len(obj_names)):
-                if obj_directions[j] == 'minimize':
+                if obj_directions[j] == "minimize":
                     pp_invert.append(obj_names[j])
 
     # In order to always hide uid and from_uid from the parallel plot,
     # we append these columns to the user-identified set of columns
-    pp_hide = hide_columns + ['uid', 'from_uid']
+    pp_hide = hide_columns + ["uid", "from_uid"]
 
     # Create plot
     exp = hip.Experiment.from_dataframe(df)
@@ -260,96 +294,100 @@ def parallel_plot_hp(df,
     # Now we update the experiment object to implement the hidden and
     # inverted columns
     exp.display_data(hip.Displays.PARALLEL_PLOT).update(
-        {
-            'hide': pp_hide,
-            'invert': pp_invert
-        }
+        {"hide": pp_hide, "invert": pp_invert}
     )
 
     # And similarly, update the data table that is rendered below the plot
-    exp.display_data(hip.Displays.TABLE).update(
-        {
-            'hide': ['uid', 'from_uid']
-        }
-    )
+    exp.display_data(hip.Displays.TABLE).update({"hide": ["uid", "from_uid"]})
 
     # The experiment object is returned so that it can be used later
     return exp
 
+
 # Modified this function based on development in the CVEN5393 repository
 
 
-def label_eps_nd(df, label_col, obj_names, obj_directions, epsilons, num_vars=0, num_constrs=0):
-  """
-  label_eps_nd: label epsilon non-dominated solutions
+def label_eps_nd(
+    df, label_col, obj_names, obj_directions, epsilons, num_vars=0, num_constrs=0
+):
+    """
+    label_eps_nd: label epsilon non-dominated solutions
 
-  This function takes a DataFrame of solutions and identifies which ones are epsilon non-dominated based on a given set of objectives, directions, and epsilon values. It adds a new boolean column to the DataFrame, marking `True` for epsilon non-dominated solutions and `False` otherwise.
+    This function takes a DataFrame of solutions and identifies which ones are epsilon non-dominated based on a given set of objectives, directions, and epsilon values. It adds a new boolean column to the DataFrame, marking `True` for epsilon non-dominated solutions and `False` otherwise.
 
-  ### Positional Arguments:
-  *   `df` (pd.DataFrame): The input DataFrame containing solution data.
-  *   `label_col` (str): The name of the new column to be added to `df` to store the boolean labels.
-  *   `obj_names` (list of str): Names of the objective columns in `df`.
-  *   `obj_directions` (list of str): Optimization direction ('minimize' or 'maximize') for each objective.
-  *   `epsilons` (list of numbers): Epsilon values for each objective, defining the desired precision for performing the epsilon non-dominance calculation.
+    ### Positional Arguments:
+    *   `df` (pd.DataFrame): The input DataFrame containing solution data.
+    *   `label_col` (str): The name of the new column to be added to `df` to store the boolean labels.
+    *   `obj_names` (list of str): Names of the objective columns in `df`.
+    *   `obj_directions` (list of str): Optimization direction ('minimize' or 'maximize') for each objective.
+    *   `epsilons` (list of numbers): Epsilon values for each objective, defining the desired precision for performing the epsilon non-dominance calculation.
 
-  ### Optional Keyword Arguments:
-  *   `num_vars` (int, optional): Number of decision variables. Defaults to 0.
-  *   `num_constrs` (int, optional): Number of constraints. Defaults to 0.
+    ### Optional Keyword Arguments:
+    *   `num_vars` (int, optional): Number of decision variables. Defaults to 0.
+    *   `num_constrs` (int, optional): Number of constraints. Defaults to 0.
 
-  ### How it works:
-  1.  **Input Validation:** Checks if all input parameters are of the correct type and format.
-  2.  **Initialize Label Column:** Creates a new column in the DataFrame (`label_col`) and sets all values to `False`.
-  3.  **Convert to Platypus Format:** Uses the `df_to_pt` function to convert the DataFrame into a list of Platypus `Solution` objects.
-  4.  **Epsilon Non-dominated Sorting:** Employs the `EpsilonBoxArchive` from Platypus to perform the epsilon non-dominated sort.
-  5.  **Label Solutions:** Identifies the `id` (original DataFrame index) of the epsilon non-dominated solutions and updates the `label_col` in the input DataFrame to `True` for these solutions.
-  6.  **Return DataFrame:** Returns the DataFrame with the new `label_col` populated.
-  """
-  # Validate input parameters
-  if not isinstance(df, pd.DataFrame):
-    raise TypeError("Input 'df' must be a pandas DataFrame.")
-  if not isinstance(label_col, str) or not label_col:
-    raise ValueError("Input 'label_col' must be a non-empty string.")
-  if label_col in df.columns:
-      raise ValueError(
-          f"label_col '{label_col}' already exists in DataFrame. Please choose a different name.")
-  if not isinstance(obj_names, list) or not all(isinstance(name, str) for name in obj_names):
-    raise TypeError("Input 'objective_names' must be a list of strings.")
-  if not obj_names:
-    raise ValueError("Input 'objective_names' cannot be empty.")
-  if not isinstance(obj_directions, list) or not all(isinstance(direction, str) for direction in obj_directions):
-    raise TypeError("Input 'objective_directions' must be a list of strings.")
-  if not all(d in ['minimize', 'maximize'] for d in obj_directions):
-    raise ValueError("Objective directions must be 'minimize' or 'maximize'.")
-  if not isinstance(epsilons, list) or not all(isinstance(e, (int, float)) for e in epsilons):
-    raise TypeError("Input 'epsilons' must be a list of numbers.")
+    ### How it works:
+    1.  **Input Validation:** Checks if all input parameters are of the correct type and format.
+    2.  **Initialize Label Column:** Creates a new column in the DataFrame (`label_col`) and sets all values to `False`.
+    3.  **Convert to Platypus Format:** Uses the `df_to_pt` function to convert the DataFrame into a list of Platypus `Solution` objects.
+    4.  **Epsilon Non-dominated Sorting:** Employs the `EpsilonBoxArchive` from Platypus to perform the epsilon non-dominated sort.
+    5.  **Label Solutions:** Identifies the `id` (original DataFrame index) of the epsilon non-dominated solutions and updates the `label_col` in the input DataFrame to `True` for these solutions.
+    6.  **Return DataFrame:** Returns the DataFrame with the new `label_col` populated.
+    """
+    # Validate input parameters
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("Input 'df' must be a pandas DataFrame.")
+    if not isinstance(label_col, str) or not label_col:
+        raise ValueError("Input 'label_col' must be a non-empty string.")
+    if label_col in df.columns:
+        raise ValueError(
+            f"label_col '{label_col}' already exists in DataFrame. Please choose a different name."
+        )
+    if not isinstance(obj_names, list) or not all(
+        isinstance(name, str) for name in obj_names
+    ):
+        raise TypeError("Input 'objective_names' must be a list of strings.")
+    if not obj_names:
+        raise ValueError("Input 'objective_names' cannot be empty.")
+    if not isinstance(obj_directions, list) or not all(
+        isinstance(direction, str) for direction in obj_directions
+    ):
+        raise TypeError("Input 'objective_directions' must be a list of strings.")
+    if not all(d in ["minimize", "maximize"] for d in obj_directions):
+        raise ValueError("Objective directions must be 'minimize' or 'maximize'.")
+    if not isinstance(epsilons, list) or not all(
+        isinstance(e, (int, float)) for e in epsilons
+    ):
+        raise TypeError("Input 'epsilons' must be a list of numbers.")
 
-  if not (len(obj_names) == len(obj_directions) == len(epsilons)):
-    raise ValueError(
-        "Lengths of 'objective_names', 'objective_directions', and 'epsilons' must all match.")
-  if not isinstance(num_vars, int) or num_vars < 0:
-    raise ValueError("Input 'nvars' must be a non-negative integer.")
-  if not isinstance(num_constrs, int) or num_constrs < 0:
-    raise ValueError("Input 'nconstrs' must be a non-negative integer.")
+    if not (len(obj_names) == len(obj_directions) == len(epsilons)):
+        raise ValueError(
+            "Lengths of 'objective_names', 'objective_directions', and 'epsilons' must all match."
+        )
+    if not isinstance(num_vars, int) or num_vars < 0:
+        raise ValueError("Input 'nvars' must be a non-negative integer.")
+    if not isinstance(num_constrs, int) or num_constrs < 0:
+        raise ValueError("Input 'nconstrs' must be a non-negative integer.")
 
-  # reset the label column
-  df[label_col] = False
+    # reset the label column
+    df[label_col] = False
 
-  # convert to platypus format
-  pt_solutions = df_to_pt(df, obj_names, obj_directions, num_vars, num_constrs)
+    # convert to platypus format
+    pt_solutions = df_to_pt(df, obj_names, obj_directions, num_vars, num_constrs)
 
-  # save the epsilon non-dominated solutions to a new list of platypus solutions
-  eps_pt = pt.EpsilonBoxArchive(epsilons)
-  for solution in pt_solutions:
-    eps_pt.add(solution)
+    # save the epsilon non-dominated solutions to a new list of platypus solutions
+    eps_pt = pt.EpsilonBoxArchive(epsilons)
+    for solution in pt_solutions:
+        eps_pt.add(solution)
 
-  # save which ids ended up being epsilon non-dominated
-  eps_ids = [sol.id for sol in eps_pt]
+    # save which ids ended up being epsilon non-dominated
+    eps_ids = [sol.id for sol in eps_pt]
 
-  # add labels to the epsilon non-dominated solutions
-  for id in eps_ids:
-    df.at[id, label_col] = True
+    # add labels to the epsilon non-dominated solutions
+    for id in eps_ids:
+        df.at[id, label_col] = True
 
-  return df
+    return df
 
 
 def append_Kmeans(df, num_clusters=3, cluster_columns=None):
@@ -379,299 +417,322 @@ def append_Kmeans(df, num_clusters=3, cluster_columns=None):
 
 
 def _resolve_config_path(output_folder, config_filename=None):
-  """Resolve a configuration XML path for legacy and newer output folder layouts."""
-  folder = Path(output_folder)
+    """Resolve a configuration XML path for legacy and newer output folder layouts."""
+    folder = Path(output_folder)
 
-  # If the caller provided an explicit config file path, treat that as authoritative.
-  # We fail fast here instead of silently falling back so path mistakes are visible.
-  if config_filename is not None:
-    candidate = folder / config_filename
-    if candidate.exists():
-      return candidate
+    # If the caller provided an explicit config file path, treat that as authoritative.
+    # We fail fast here instead of silently falling back so path mistakes are visible.
+    if config_filename is not None:
+        candidate = folder / config_filename
+        if candidate.exists():
+            return candidate
+        raise FileNotFoundError(
+            f"Configuration XML not found: {candidate}. "
+            f"Pass a valid config filename or set config_filename=None for auto-discovery."
+        )
+
+    # Ordered fallback list:
+    # 1) historical CopyOfConfiguration.xml locations
+    # 2) any XML file in common copy folders (for newer naming conventions)
+    candidates = [
+        folder / "CopyOfConfiguration.xml",
+        folder / "InputFilesCopy" / "CopyOfConfiguration.xml",
+        folder / "Input Files Copy" / "CopyOfConfiguration.xml",
+    ]
+
+    # Extend the candidate set with all XML files in likely locations.
+    # This makes the helper robust when API versions preserve the original
+    # configuration filename instead of copying to CopyOfConfiguration.xml.
+    for subfolder in ["InputFilesCopy", "Input Files Copy", ""]:
+        search_dir = folder / subfolder if subfolder else folder
+        if search_dir.exists():
+            candidates.extend(sorted(search_dir.glob("*.xml")))
+
+    # Keep first-match behavior while avoiding duplicate path checks.
+    # First match is intentional because candidate ordering encodes priority.
+    seen = set()
+    for candidate in candidates:
+        candidate_str = str(candidate)
+        if candidate_str in seen:
+            continue
+        seen.add(candidate_str)
+        if candidate.exists() and candidate.is_file():
+            return candidate
+
     raise FileNotFoundError(
-      f"Configuration XML not found: {candidate}. "
-      f"Pass a valid config filename or set config_filename=None for auto-discovery."
+        f"No configuration XML found in {folder}. "
+        f"Expected CopyOfConfiguration.xml or an XML file under InputFilesCopy/Input Files Copy."
     )
 
-  # Ordered fallback list:
-  # 1) historical CopyOfConfiguration.xml locations
-  # 2) any XML file in common copy folders (for newer naming conventions)
-  candidates = [
-    folder / "CopyOfConfiguration.xml",
-    folder / "InputFilesCopy" / "CopyOfConfiguration.xml",
-    folder / "Input Files Copy" / "CopyOfConfiguration.xml",
-  ]
 
-  # Extend the candidate set with all XML files in likely locations.
-  # This makes the helper robust when API versions preserve the original
-  # configuration filename instead of copying to CopyOfConfiguration.xml.
-  for subfolder in ["InputFilesCopy", "Input Files Copy", ""]:
-    search_dir = folder / subfolder if subfolder else folder
-    if search_dir.exists():
-      candidates.extend(sorted(search_dir.glob("*.xml")))
+def load_objective_names(
+    output_folder,
+    config_filename=None,
+    return_config_path=False,
+    include_directions=False,
+):
+    """Load objective names from an output folder configuration XML.
 
-  # Keep first-match behavior while avoiding duplicate path checks.
-  # First match is intentional because candidate ordering encodes priority.
-  seen = set()
-  for candidate in candidates:
-    candidate_str = str(candidate)
-    if candidate_str in seen:
-      continue
-    seen.add(candidate_str)
-    if candidate.exists() and candidate.is_file():
-      return candidate
+    Args:
+      output_folder: Search output folder containing copied input files.
+      config_filename: Optional relative path to a specific XML file. If None,
+        auto-discovers legacy CopyOfConfiguration.xml or newer XML names.
+      return_config_path: If True, also return the resolved config XML path.
+      include_directions: If True, also return the list of objective directions.
+    """
+    if not isinstance(return_config_path, bool):
+        raise TypeError("Input 'return_config_path' must be a boolean.")
+    if not isinstance(include_directions, bool):
+        raise TypeError("Input 'include_directions' must be a boolean.")
 
-  raise FileNotFoundError(
-    f"No configuration XML found in {folder}. "
-    f"Expected CopyOfConfiguration.xml or an XML file under InputFilesCopy/Input Files Copy."
-  )
+    config_path = _resolve_config_path(output_folder, config_filename=config_filename)
+    _decision_variable_names, objective_names, objective_directions = process_xml(
+        config_path,
+        include_objective_directions=True,
+        default_objective_direction="minimize",
+    )
 
-
-def load_objective_names(output_folder, config_filename=None, return_config_path=False, include_directions=False):
-  """Load objective names from an output folder configuration XML.
-
-  Args:
-    output_folder: Search output folder containing copied input files.
-    config_filename: Optional relative path to a specific XML file. If None,
-      auto-discovers legacy CopyOfConfiguration.xml or newer XML names.
-    return_config_path: If True, also return the resolved config XML path.
-    include_directions: If True, also return the list of objective directions.
-  """
-  if not isinstance(return_config_path, bool):
-    raise TypeError("Input 'return_config_path' must be a boolean.")
-  if not isinstance(include_directions, bool):
-    raise TypeError("Input 'include_directions' must be a boolean.")
-
-  config_path = _resolve_config_path(output_folder, config_filename=config_filename)
-  _decision_variable_names, objective_names, objective_directions = process_xml(
-    config_path,
-    include_objective_directions=True,
-    default_objective_direction="minimize"
-  )
-
-  if include_directions and return_config_path:
-    return objective_names, objective_directions, config_path
-  if include_directions:
-    return objective_names, objective_directions
-  if return_config_path:
-    return objective_names, config_path
-  return objective_names
+    if include_directions and return_config_path:
+        return objective_names, objective_directions, config_path
+    if include_directions:
+        return objective_names, objective_directions
+    if return_config_path:
+        return objective_names, config_path
+    return objective_names
 
 
 def resolve_solutions_csv(output_folder, solutions_filename=None):
-  """Resolve a solutions CSV path across canonical and user-renamed naming patterns."""
-  folder = Path(output_folder)
+    """Resolve a solutions CSV path across canonical and user-renamed naming patterns."""
+    folder = Path(output_folder)
 
-  if solutions_filename is not None:
-    candidate = folder / solutions_filename
-    if candidate.exists():
-      return candidate
-    raise FileNotFoundError(f"Solutions CSV not found: {candidate}")
+    if solutions_filename is not None:
+        candidate = folder / solutions_filename
+        if candidate.exists():
+            return candidate
+        raise FileNotFoundError(f"Solutions CSV not found: {candidate}")
 
-  # Preferred canonical outputs first (stable default behavior).
-  candidates = [
-    folder / "Plot.csv",
-    folder / "Plot_with_clusters.csv",
-    folder / "NondominatedSolutions.ToHiPlot.csv",
-    folder / "NondominatedSolutions.csv",
-  ]
+    # Preferred canonical outputs first (stable default behavior).
+    candidates = [
+        folder / "Plot.csv",
+        folder / "Plot_with_clusters.csv",
+        folder / "NondominatedSolutions.ToHiPlot.csv",
+        folder / "NondominatedSolutions.csv",
+    ]
 
-  # Include contextual variants generated by iterative workflows.
-  candidates.extend(sorted(folder.glob("Plot*.csv")))
-  candidates.extend(sorted(folder.glob("NondominatedSolutions*.csv")))
+    # Include contextual variants generated by iterative workflows.
+    candidates.extend(sorted(folder.glob("Plot*.csv")))
+    candidates.extend(sorted(folder.glob("NondominatedSolutions*.csv")))
 
-  # Preserve first-match priority while removing duplicate paths.
-  seen = set()
-  deduped_candidates = []
-  for candidate in candidates:
-    candidate_str = str(candidate)
-    if candidate_str in seen:
-      continue
-    seen.add(candidate_str)
-    deduped_candidates.append(candidate)
+    # Preserve first-match priority while removing duplicate paths.
+    seen = set()
+    deduped_candidates = []
+    for candidate in candidates:
+        candidate_str = str(candidate)
+        if candidate_str in seen:
+            continue
+        seen.add(candidate_str)
+        deduped_candidates.append(candidate)
 
-  for candidate in deduped_candidates:
-    if candidate.exists() and candidate.is_file():
-      return candidate
+    for candidate in deduped_candidates:
+        if candidate.exists() and candidate.is_file():
+            return candidate
 
-  raise FileNotFoundError(
-    f"No solutions CSV found in {folder}. Tried: {[c.name for c in deduped_candidates]}"
-  )
-
-
-def load_objectives_and_solutions(output_folder,
-                                 config_filename=None,
-                                 solutions_filename=None,
-                                 return_paths=False,
-                                 include_directions=False):
-  """Load objective names and solutions DataFrame from an output folder.
-
-  Args:
-    output_folder: Search output folder containing copied input files and result CSVs.
-    config_filename: Optional relative config XML path; auto-discovered when None.
-    solutions_filename: Optional relative solutions CSV path; auto-discovered when None.
-    return_paths: If True, also return resolved config and CSV paths.
-    include_directions: If True, also return the list of objective directions.
-  """
-  if not isinstance(return_paths, bool):
-    raise TypeError("Input 'return_paths' must be a boolean.")
-  if not isinstance(include_directions, bool):
-    raise TypeError("Input 'include_directions' must be a boolean.")
-
-  if include_directions:
-    objective_names, objective_directions, config_path = load_objective_names(
-      output_folder,
-      config_filename=config_filename,
-      return_config_path=True,
-      include_directions=True,
+    raise FileNotFoundError(
+        f"No solutions CSV found in {folder}. Tried: {[c.name for c in deduped_candidates]}"
     )
-  else:
-    objective_names, config_path = load_objective_names(
-      output_folder,
-      config_filename=config_filename,
-      return_config_path=True,
-    )
-  solutions_path = resolve_solutions_csv(output_folder, solutions_filename=solutions_filename)
-  solutions = pd.read_csv(solutions_path)
-  if solutions.empty:
-    raise ValueError(f"Solutions file is empty: {solutions_path}")
 
-  result = (objective_names, solutions)
-  if include_directions:
-    result += (objective_directions,)
-  if return_paths:
-    result += (config_path, solutions_path)
-  return result
+
+def load_objectives_and_solutions(
+    output_folder,
+    config_filename=None,
+    solutions_filename=None,
+    return_paths=False,
+    include_directions=False,
+):
+    """Load objective names and solutions DataFrame from an output folder.
+
+    Args:
+      output_folder: Search output folder containing copied input files and result CSVs.
+      config_filename: Optional relative config XML path; auto-discovered when None.
+      solutions_filename: Optional relative solutions CSV path; auto-discovered when None.
+      return_paths: If True, also return resolved config and CSV paths.
+      include_directions: If True, also return the list of objective directions.
+    """
+    if not isinstance(return_paths, bool):
+        raise TypeError("Input 'return_paths' must be a boolean.")
+    if not isinstance(include_directions, bool):
+        raise TypeError("Input 'include_directions' must be a boolean.")
+
+    if include_directions:
+        objective_names, objective_directions, config_path = load_objective_names(
+            output_folder,
+            config_filename=config_filename,
+            return_config_path=True,
+            include_directions=True,
+        )
+    else:
+        objective_names, config_path = load_objective_names(
+            output_folder,
+            config_filename=config_filename,
+            return_config_path=True,
+        )
+    solutions_path = resolve_solutions_csv(
+        output_folder, solutions_filename=solutions_filename
+    )
+    solutions = pd.read_csv(solutions_path)
+    if solutions.empty:
+        raise ValueError(f"Solutions file is empty: {solutions_path}")
+
+    result = (objective_names, solutions)
+    if include_directions:
+        result += (objective_directions,)
+    if return_paths:
+        result += (config_path, solutions_path)
+    return result
 
 
 def normalize_for_radar(solutions, objective_names):
-  """Return normalized radar values and objective labels with closure for polygon plotting."""
-  if not isinstance(solutions, pd.DataFrame):
-    raise TypeError("Input 'solutions' must be a pandas DataFrame.")
-  if not isinstance(objective_names, list) or not objective_names or not all(isinstance(n, str) for n in objective_names):
-    raise TypeError("Input 'objective_names' must be a non-empty list of strings.")
+    """Return normalized radar values and objective labels with closure for polygon plotting."""
+    if not isinstance(solutions, pd.DataFrame):
+        raise TypeError("Input 'solutions' must be a pandas DataFrame.")
+    if (
+        not isinstance(objective_names, list)
+        or not objective_names
+        or not all(isinstance(n, str) for n in objective_names)
+    ):
+        raise TypeError("Input 'objective_names' must be a non-empty list of strings.")
 
-  objectives_with_closure = objective_names + [objective_names[0]]
-  missing = [c for c in objectives_with_closure if c not in solutions.columns]
-  if missing:
-    raise ValueError(f"Objective columns missing from DataFrame: {missing}")
+    objectives_with_closure = objective_names + [objective_names[0]]
+    missing = [c for c in objectives_with_closure if c not in solutions.columns]
+    if missing:
+        raise ValueError(f"Objective columns missing from DataFrame: {missing}")
 
-  normalized = solutions.copy(deep=True)
-  scaler = MinMaxScaler()
-  normalized[objectives_with_closure] = scaler.fit_transform(-1.0 * normalized[objectives_with_closure])
-  return normalized, objectives_with_closure
+    normalized = solutions.copy(deep=True)
+    scaler = MinMaxScaler()
+    normalized[objectives_with_closure] = scaler.fit_transform(
+        -1.0 * normalized[objectives_with_closure]
+    )
+    return normalized, objectives_with_closure
 
 
 def build_radar_figure(normalized_solutions, objectives_with_closure, showlegend=False):
-  """Create a Plotly radar figure from normalized solution values."""
-  if not isinstance(normalized_solutions, pd.DataFrame):
-    raise TypeError("Input 'normalized_solutions' must be a pandas DataFrame.")
-  if not isinstance(objectives_with_closure, list) or not all(isinstance(n, str) for n in objectives_with_closure):
-    raise TypeError("Input 'objectives_with_closure' must be a list of strings.")
-  if not isinstance(showlegend, bool):
-    raise TypeError("Input 'showlegend' must be a boolean.")
+    """Create a Plotly radar figure from normalized solution values."""
+    if not isinstance(normalized_solutions, pd.DataFrame):
+        raise TypeError("Input 'normalized_solutions' must be a pandas DataFrame.")
+    if not isinstance(objectives_with_closure, list) or not all(
+        isinstance(n, str) for n in objectives_with_closure
+    ):
+        raise TypeError("Input 'objectives_with_closure' must be a list of strings.")
+    if not isinstance(showlegend, bool):
+        raise TypeError("Input 'showlegend' must be a boolean.")
 
-  fig = go.Figure()
-  for i in range(len(normalized_solutions)):
-    fig.add_trace(go.Scatterpolar(
-      r=normalized_solutions.iloc[i][objectives_with_closure].to_numpy(),
-      theta=objectives_with_closure,
-      fill='none',
-      name=f"Solution {i}",
-      opacity=0.5,
-    ))
+    fig = go.Figure()
+    for i in range(len(normalized_solutions)):
+        fig.add_trace(
+            go.Scatterpolar(
+                r=normalized_solutions.iloc[i][objectives_with_closure].to_numpy(),
+                theta=objectives_with_closure,
+                fill="none",
+                name=f"Solution {i}",
+                opacity=0.5,
+            )
+        )
 
-  fig.update_layout(
-    polar=dict(radialaxis=dict(visible=True)),
-    showlegend=showlegend
-  )
-  return fig
+    fig.update_layout(polar=dict(radialaxis=dict(visible=True)), showlegend=showlegend)
+    return fig
 
 
-def run_eps_experiment(output_folder, objective_names, objective_directions,
-                       solutions_base, experiment_name, epsilons):
-  """Apply epsilon non-dominance labeling and write named output files.
+def run_eps_experiment(
+    output_folder,
+    objective_names,
+    objective_directions,
+    solutions_base,
+    experiment_name,
+    epsilons,
+):
+    """Apply epsilon non-dominance labeling and write named output files.
 
-  This is the core computation step for one epsilon experiment: it labels
-  solutions, writes two CSVs and one HTML parallel-plot file, and returns
-  a summary dict so callers can report results without coupling to the I/O.
+    This is the core computation step for one epsilon experiment: it labels
+    solutions, writes two CSVs and one HTML parallel-plot file, and returns
+    a summary dict so callers can report results without coupling to the I/O.
 
-  Args:
-    output_folder: Directory where output files are written.
-    objective_names: List of objective column names.
-    objective_directions: List of 'minimize'/'maximize' strings matching objective_names.
-    solutions_base: DataFrame of candidate solutions (not mutated; a copy is made).
-    experiment_name: Filesystem-safe string used as a suffix in all output filenames.
-    epsilons: List of epsilon values, one per objective.
+    Args:
+      output_folder: Directory where output files are written.
+      objective_names: List of objective column names.
+      objective_directions: List of 'minimize'/'maximize' strings matching objective_names.
+      solutions_base: DataFrame of candidate solutions (not mutated; a copy is made).
+      experiment_name: Filesystem-safe string used as a suffix in all output filenames.
+      epsilons: List of epsilon values, one per objective.
 
-  Returns:
-    dict with keys:
-      'n_total'    — total number of input solutions
-      'n_retained' — number of epsilon non-dominated solutions
-      'labeled_path'  — Path written for all solutions with eps_nd label
-      'eps_only_path' — Path written for epsilon non-dominated solutions only
-      'html_path'     — Path written for HiPlot parallel-plot HTML
-  """
-  if not isinstance(solutions_base, pd.DataFrame):
-    raise TypeError("Input 'solutions_base' must be a pandas DataFrame.")
-  if not isinstance(experiment_name, str) or not experiment_name:
-    raise ValueError("Input 'experiment_name' must be a non-empty string.")
+    Returns:
+      dict with keys:
+        'n_total'    — total number of input solutions
+        'n_retained' — number of epsilon non-dominated solutions
+        'labeled_path'  — Path written for all solutions with eps_nd label
+        'eps_only_path' — Path written for epsilon non-dominated solutions only
+        'html_path'     — Path written for HiPlot parallel-plot HTML
+    """
+    if not isinstance(solutions_base, pd.DataFrame):
+        raise TypeError("Input 'solutions_base' must be a pandas DataFrame.")
+    if not isinstance(experiment_name, str) or not experiment_name:
+        raise ValueError("Input 'experiment_name' must be a non-empty string.")
 
-  folder = Path(output_folder)
-  solutions = solutions_base.copy()
-  solutions = label_eps_nd(
-    solutions,
-    label_col="eps_nd",
-    obj_names=objective_names,
-    obj_directions=objective_directions,
-    epsilons=epsilons,
-  )
-  eps_solutions = solutions[solutions["eps_nd"]].copy()
+    folder = Path(output_folder)
+    solutions = solutions_base.copy()
+    solutions = label_eps_nd(
+        solutions,
+        label_col="eps_nd",
+        obj_names=objective_names,
+        obj_directions=objective_directions,
+        epsilons=epsilons,
+    )
+    eps_solutions = solutions[solutions["eps_nd"]].copy()
 
-  labeled_path = folder / f"Plot_with_eps_labels_{experiment_name}.csv"
-  eps_only_path = folder / f"Plot_with_only_eps_{experiment_name}.csv"
-  html_path = folder / f"Plot_with_only_eps_{experiment_name}.html"
+    labeled_path = folder / f"Plot_with_eps_labels_{experiment_name}.csv"
+    eps_only_path = folder / f"Plot_with_only_eps_{experiment_name}.csv"
+    html_path = folder / f"Plot_with_only_eps_{experiment_name}.html"
 
-  solutions.to_csv(labeled_path)
-  eps_solutions.to_csv(eps_only_path)
-  parallel_plot_hp(
-    eps_solutions,
-    obj_names=objective_names,
-    obj_directions=objective_directions,
-    hide_columns=["Solution"],
-  ).to_html(html_path)
+    solutions.to_csv(labeled_path)
+    eps_solutions.to_csv(eps_only_path)
+    parallel_plot_hp(
+        eps_solutions,
+        obj_names=objective_names,
+        obj_directions=objective_directions,
+        hide_columns=["Solution"],
+    ).to_html(html_path)
 
-  return {
-    "n_total": len(solutions),
-    "n_retained": len(eps_solutions),
-    "labeled_path": labeled_path,
-    "eps_only_path": eps_only_path,
-    "html_path": html_path,
-  }
+    return {
+        "n_total": len(solutions),
+        "n_retained": len(eps_solutions),
+        "labeled_path": labeled_path,
+        "eps_only_path": eps_only_path,
+        "html_path": html_path,
+    }
 
 
 def log_eps_experiment(log_path, entry):
-  """Write a single experiment record to a JSON file.
+    """Write a single experiment record to a JSON file.
 
-  One file is written per experiment. If the file already exists it is
-  overwritten (e.g. when re-running an experiment with the same name).
-  Path objects in the entry are automatically serialized to strings.
+    One file is written per experiment. If the file already exists it is
+    overwritten (e.g. when re-running an experiment with the same name).
+    Path objects in the entry are automatically serialized to strings.
 
-  Args:
-    log_path: Path-like destination for the JSON file.
-    entry: dict describing the experiment. All values must be JSON-serializable
-      or Path objects (which are converted to strings automatically).
-  """
-  if not isinstance(entry, dict):
-    raise TypeError("Input 'entry' must be a dict.")
+    Args:
+      log_path: Path-like destination for the JSON file.
+      entry: dict describing the experiment. All values must be JSON-serializable
+        or Path objects (which are converted to strings automatically).
+    """
+    if not isinstance(entry, dict):
+        raise TypeError("Input 'entry' must be a dict.")
 
-  log_path = Path(log_path)
+    log_path = Path(log_path)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
 
-  def _serialize(obj):
-    if isinstance(obj, Path):
-      return str(obj)
-    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+    def _serialize(obj):
+        if isinstance(obj, Path):
+            return str(obj)
+        raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
-  with open(log_path, "w", encoding="utf-8") as f:
-    json.dump(entry, f, indent=2, default=_serialize)
-    f.write("\n")
+    with open(log_path, "w", encoding="utf-8") as f:
+        json.dump(entry, f, indent=2, default=_serialize)
+        f.write("\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ Source = "https://github.com/jrkasprzyk/parasolpy"
 
 [project.scripts]
 parasolpy-tradeoff = "parasolpy.dash_tools:main"
+parasolpy-rdf = "parasolpy.rdf:main"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -1,7 +1,7 @@
 """
 Tests for parasolpy.rdf (RDF parser + CSV converter CLI).
 
-Uses a synthetic sample file in public/rw-sample-data/ (safe to commit).
+Uses a synthetic sample file in parasolpy/data/ (safe to commit).
 """
 
 from __future__ import annotations

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -1,0 +1,375 @@
+"""
+Tests for parasolpy.rdf (RDF parser + CSV converter CLI).
+
+Uses a synthetic sample file in public/rw-sample-data/ (safe to commit).
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import sys
+import unittest
+from pathlib import Path
+
+from parasolpy.rdf import list_slots, parse_rdf
+
+REPO = Path(__file__).parent.parent
+SAMPLES = REPO / "parasolpy" / "data"
+
+TRACES = SAMPLES / "sample_traces.rdf"   # 3 runs, 5 timesteps, 5 slots (3 series + 2 scalar)
+
+
+class TestSampleTraces(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rdf = parse_rdf(TRACES)
+
+    def test_meta_run_count(self):
+        self.assertEqual(self.rdf["meta"]["number_of_runs"], "3")
+
+    def test_actual_run_count(self):
+        self.assertEqual(len(self.rdf["runs"]), 3)
+
+    def test_slot_count_per_run(self):
+        for run in self.rdf["runs"]:
+            self.assertEqual(len(run["slots"]), 5)
+
+    def test_slot_names(self):
+        expected = {
+            "Example Reservoir.Pool Elevation",
+            "Example Reservoir.Outflow",
+            "Example Reservoir.Turbine Release",
+            "Run Management.Trace Historical Year",
+            "Run Management.Historical Year Percent of Average",
+        }
+        self.assertEqual(set(self.rdf["runs"][0]["slots"].keys()), expected)
+
+    def test_series_slot_value_count(self):
+        for run in self.rdf["runs"]:
+            slot = run["slots"]["Example Reservoir.Pool Elevation"]
+            self.assertFalse(slot["scalar"])
+            self.assertEqual(len(slot["values"]), 5)
+
+    def test_series_slot_values(self):
+        vals = self.rdf["runs"][0]["slots"]["Example Reservoir.Pool Elevation"]["values"]
+        self.assertAlmostEqual(vals[0], 1100.0)
+        self.assertAlmostEqual(vals[-1], 1098.0)
+
+    def test_scalar_slot(self):
+        slot = self.rdf["runs"][0]["slots"]["Run Management.Trace Historical Year"]
+        self.assertTrue(slot["scalar"])
+        self.assertEqual(len(slot["values"]), 1)
+        self.assertAlmostEqual(slot["values"][0], 1988.0)
+
+    def test_units(self):
+        slot = self.rdf["runs"][0]["slots"]["Example Reservoir.Pool Elevation"]
+        self.assertEqual(slot["units"], "feet")
+
+    def test_timestamp_normalization(self):
+        times = self.rdf["runs"][0]["times"]
+        self.assertEqual(times[0], "2024-01-01")
+        self.assertEqual(times[-1], "2024-01-05")
+        self.assertEqual(len(times), 5)
+
+    def test_trace_ids(self):
+        traces = [r["preamble"]["trace"] for r in self.rdf["runs"]]
+        self.assertEqual(traces, ["1", "2", "3"])
+
+    def test_list_slots_returns_metadata(self):
+        slots = list_slots(self.rdf)
+        self.assertEqual(len(slots), 5)
+        keys = [s["key"] for s in slots]
+        self.assertIn("Example Reservoir.Pool Elevation", keys)
+
+
+class TestTimestampNormalization(unittest.TestCase):
+    def test_single_digit_month_day(self):
+        from parasolpy.rdf import _normalize_ts
+
+        self.assertEqual(_normalize_ts("2025-10-2 24:00"), "2025-10-02")
+        self.assertEqual(_normalize_ts("2026-1-15 24:00"), "2026-01-15")
+        self.assertEqual(_normalize_ts("2026-10-1 24:00"), "2026-10-01")
+
+
+class TestParserErrors(unittest.TestCase):
+    def test_wrong_extension_raises(self):
+        with self.assertRaises(ValueError):
+            parse_rdf("model.csv")
+
+    def test_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            parse_rdf("nonexistent.rdf")
+
+
+class TestCLIConvert(unittest.TestCase):
+    def _run_cli(self, *extra_args):
+        import subprocess
+
+        return subprocess.run(
+            [sys.executable, "-m", "parasolpy.rdf", *extra_args],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_info_command(self):
+        result = self._run_cli("info", str(TRACES))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Example Reservoir.Pool Elevation", result.stdout)
+        self.assertIn("feet", result.stdout)
+        self.assertIn("count         : 3", result.stdout)
+
+    def test_default_format_is_wide(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            out = f.name
+        try:
+            result = self._run_cli(
+                "convert",
+                str(TRACES),
+                "--slot",
+                "Example Reservoir.Pool Elevation",
+                "--output",
+                out,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            with open(out, newline="") as f:
+                rows = list(csv.reader(f))
+            self.assertEqual(len(rows), 6)  # 1 header + 5 data rows
+            self.assertEqual(len(rows[0]), 4)  # date + 3 trace cols
+            self.assertEqual(rows[0][0], "date")
+        finally:
+            os.unlink(out)
+
+    def test_wide_csv_dimensions(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            out = f.name
+        try:
+            result = self._run_cli(
+                "convert",
+                str(TRACES),
+                "--slot",
+                "Example Reservoir.Pool Elevation",
+                "--output",
+                out,
+                "--format",
+                "wide",
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            with open(out, newline="") as f:
+                rows = list(csv.reader(f))
+            self.assertEqual(len(rows), 6)  # 1 header + 5 data rows
+            self.assertEqual(len(rows[0]), 4)  # date + 3 trace cols
+            self.assertEqual(rows[0][0], "date")
+            self.assertEqual(rows[1][0], "2024-01-01")
+            self.assertEqual(rows[0][1], "trace_1")
+        finally:
+            os.unlink(out)
+
+    def test_long_csv_dimensions(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            out = f.name
+        try:
+            result = self._run_cli(
+                "convert",
+                str(TRACES),
+                "--slot",
+                "Example Reservoir.Pool Elevation",
+                "--output",
+                out,
+                "--format",
+                "long",
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            with open(out, newline="") as f:
+                rows = list(csv.reader(f))
+            self.assertEqual(len(rows), 1 + 3 * 5)  # 1 header + 15 data rows
+            self.assertEqual(rows[0], ["date", "trace", "value"])
+        finally:
+            os.unlink(out)
+
+    def test_sidecar_label_values_vary_per_trace(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            out = f.name
+        labels_path = Path(out).with_name(Path(out).stem + "_labels.csv")
+        try:
+            result = self._run_cli(
+                "convert",
+                str(TRACES),
+                "--slot",
+                "Example Reservoir.Pool Elevation",
+                "--output",
+                out,
+                "--format",
+                "wide",
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+            with open(labels_path, newline="") as f:
+                rows = list(csv.DictReader(f))
+
+            values = [row["Trace Historical Year"] for row in rows]
+            self.assertEqual(values, ["1988.0", "1995.0", "2003.0"])
+            self.assertEqual(len(set(values)), 3)
+        finally:
+            if os.path.exists(out):
+                os.unlink(out)
+            if labels_path.exists():
+                os.unlink(labels_path)
+
+    def test_stacked_header_format(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            out = f.name
+        try:
+            result = self._run_cli(
+                "convert",
+                str(TRACES),
+                "--slot",
+                "Example Reservoir.Pool Elevation",
+                "--output",
+                out,
+                "--format",
+                "stacked",
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+            with open(out, newline="") as f:
+                rows = list(csv.reader(f))
+
+            self.assertEqual(rows[0][0], "Trace Historical Year")
+            self.assertEqual(len(rows[0]), 4)  # label name + 3 trace values
+            self.assertEqual(rows[1][0], "Historical Year Percent of Average")
+            self.assertIn(rows[2][0], ["date", "year"])
+            self.assertEqual(rows[2][1:], ["trace_1", "trace_2", "trace_3"])
+            self.assertGreaterEqual(len(rows), 8)
+            self.assertEqual(rows[3][0], "2024-01-01")
+        finally:
+            os.unlink(out)
+
+    def test_wide_sidecar_column_alignment(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            out = f.name
+        labels_path = Path(out).with_name(Path(out).stem + "_labels.csv")
+        try:
+            result = self._run_cli(
+                "convert",
+                str(TRACES),
+                "--slot",
+                "Example Reservoir.Pool Elevation",
+                "--output",
+                out,
+                "--format",
+                "wide",
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+            with open(out, newline="") as f:
+                wide_rows = list(csv.reader(f))
+            with open(labels_path, newline="") as f:
+                sidecar_rows = list(csv.DictReader(f))
+
+            wide_headers = wide_rows[0][1:]
+            sidecar_columns = [row["column"] for row in sidecar_rows]
+
+            self.assertEqual(len(sidecar_columns), len(wide_headers))
+            for col in sidecar_columns:
+                self.assertIn(col, wide_headers)
+        finally:
+            if os.path.exists(out):
+                os.unlink(out)
+            if labels_path.exists():
+                os.unlink(labels_path)
+
+    def test_long_format_still_works(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            out = f.name
+        try:
+            result = self._run_cli(
+                "convert",
+                str(TRACES),
+                "--slot",
+                "Example Reservoir.Pool Elevation",
+                "--output",
+                out,
+                "--format",
+                "long",
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            with open(out, newline="") as f:
+                rows = list(csv.reader(f))
+
+            self.assertEqual(rows[0], ["date", "trace", "value"])
+            self.assertEqual(rows[1], ["2024-01-01", "trace_1", "1100.0"])
+            self.assertEqual(rows[6], ["2024-01-01", "trace_2", "1101.0"])
+        finally:
+            os.unlink(out)
+
+    def test_enriched_csv_dimensions(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            out = f.name
+        try:
+            result = self._run_cli(
+                "convert",
+                str(TRACES),
+                "--slot",
+                "Example Reservoir.Pool Elevation",
+                "--output",
+                out,
+                "--format",
+                "enriched",
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            with open(out, newline="") as f:
+                rows = list(csv.reader(f))
+            self.assertEqual(len(rows), 1 + 3 * 5)  # 1 header + 15 data rows
+            self.assertEqual(
+                rows[0],
+                [
+                    "date",
+                    "trace",
+                    "value",
+                    "Trace Historical Year",
+                    "Historical Year Percent of Average",
+                ],
+            )
+            self.assertEqual(rows[1][3], "1988.0")
+        finally:
+            os.unlink(out)
+
+    def test_invalid_slot_exits_nonzero(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            out = f.name
+        try:
+            result = self._run_cli(
+                "convert",
+                str(TRACES),
+                "--slot",
+                "Does Not.Exist",
+                "--output",
+                out,
+            )
+            self.assertNotEqual(result.returncode, 0)
+        finally:
+            if os.path.exists(out):
+                os.unlink(out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This pull request introduces several improvements and additions across the codebase, focusing on enhanced CLI support for RDF files, improved error handling, better parameter validation, and the inclusion of new example data and scripts. The changes also include code quality improvements for readability and maintainability.

**New CLI and Example Support for RDF Files:**

* Added a new batch script `rdf_cli_commands.bat` in the `examples` directory to demonstrate usage of the RDF CLI on a bundled sample file, including conversion to various CSV formats.
* Added a synthetic sample RDF file, `sample_traces.rdf`, to `parasolpy/data` for testing and demonstration purposes.

**RDF Integration in Main Package:**

* Exposed `parse_rdf` and `list_slots` in the main `parasolpy` package and documented them in the quick start and `__all__` list, making them available for import and usage. [[1]](diffhunk://#diff-267fa94a72c97a0b0ff71ecc8a1e628fe7a7d3a54c0f66d7da09bc66ebe22185R44) [[2]](diffhunk://#diff-267fa94a72c97a0b0ff71ecc8a1e628fe7a7d3a54c0f66d7da09bc66ebe22185R96) [[3]](diffhunk://#diff-267fa94a72c97a0b0ff71ecc8a1e628fe7a7d3a54c0f66d7da09bc66ebe22185R157-R159)

**Improved Error Handling and Validation:**

* Enhanced error handling in `load_experiment_epsilons` to provide a clear error message if the experiment log file cannot be parsed as JSON.
* Improved and standardized parameter validation and error messages in `tradeoff.py` (notably in `df_to_pt` and `parallel_plot_hp`), making the code more robust and user-friendly. [[1]](diffhunk://#diff-a54ea6af6718fb7c7c7c07c0685b94910e7abcd025191006a04dd7d31dc705f6L52-R62) [[2]](diffhunk://#diff-a54ea6af6718fb7c7c7c07c0685b94910e7abcd025191006a04dd7d31dc705f6L82-R107) [[3]](diffhunk://#diff-a54ea6af6718fb7c7c7c07c0685b94910e7abcd025191006a04dd7d31dc705f6L148-R256) [[4]](diffhunk://#diff-a54ea6af6718fb7c7c7c07c0685b94910e7abcd025191006a04dd7d31dc705f6L234-R279) [[5]](diffhunk://#diff-a54ea6af6718fb7c7c7c07c0685b94910e7abcd025191006a04dd7d31dc705f6L263-R312)

**Other Improvements:**

* Added normalization to the weights in `choose_analog_index` in `nowak.py` for correctness.
* Updated docstring in `ism.py` to clarify the meaning of the returned indices.
* Added a warning in `dash_tools.py` if an unrecognized colorscale is specified, falling back to 'viridis'. [[1]](diffhunk://#diff-de7401b5a0ab9f44023116dae730241e6191742e23723916b770a935bc697c10R4) [[2]](diffhunk://#diff-de7401b5a0ab9f44023116dae730241e6191742e23723916b770a935bc697c10R72-R76)